### PR TITLE
apply dependency management

### DIFF
--- a/simple-jpa/build.gradle
+++ b/simple-jpa/build.gradle
@@ -9,8 +9,9 @@ buildscript {
   dependencies {
     classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
     classpath "com.diffplug.spotless:spotless-plugin-gradle:3.10.0"
-    classpath "de.thetaphi:forbiddenapis:2.4.1"
-    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.1"
+    classpath "de.thetaphi:forbiddenapis:2.5"
+    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.2"
+    classpath "io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE"
   }
 }
 
@@ -24,6 +25,7 @@ apply plugin: "jacoco"
 apply plugin: "de.thetaphi.forbiddenapis"
 apply plugin: "org.springframework.boot"
 apply plugin: "com.diffplug.gradle.spotless"
+apply plugin: "io.spring.dependency-management"
 
 group = "com.github.wreulicke"
 version = "0.0.1-SNAPSHOT"


### PR DESCRIPTION

Spring 2系からdependency management pluginの自動適用（とそれに伴うbomの読み込み）が無効になるので
適用した